### PR TITLE
Fixed entity-tracking-range: player and increased tracking range for fireballs

### DIFF
--- a/server/configs/spigot.yml
+++ b/server/configs/spigot.yml
@@ -5,7 +5,11 @@ stats:
 world-settings:
   default:
     entity-tracking-range:
-      player: 256
+      players: 256
+      animals: 48
+      monsters: 48
+      misc: 256
+      other: 256
     verbose: false
 advancements:
   disable-saving: true


### PR DESCRIPTION
A typo was in the spigot.yml file where `players` was mistyped as `player` under `entity-tracking-range`.

`players` is non-inclusive of arrows, fireballs and TNT and therefore `other` and `misc` have also had their tracking range increased to `256`.