### PR TITLE
Fix #21 Prevent players from breaking obsidian

### DIFF
--- a/plugin/src/main/java/org/astropeci/omw/OpenMissileWarsPlugin.java
+++ b/plugin/src/main/java/org/astropeci/omw/OpenMissileWarsPlugin.java
@@ -78,6 +78,7 @@ public class OpenMissileWarsPlugin extends JavaPlugin {
         registerEventHandler(pistonBreakHandler);
 
         pistonBreakHandler.register();
+        registerEventHandler(new ObsidianBreakPreventer());
     }
 
     private void registerEventHandler(Listener listener) {

--- a/plugin/src/main/java/org/astropeci/omw/listeners/ObsidianBreakPreventer.java
+++ b/plugin/src/main/java/org/astropeci/omw/listeners/ObsidianBreakPreventer.java
@@ -1,0 +1,16 @@
+package org.astropeci.omw.listeners;
+
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+
+public class ObsidianBreakPreventer implements Listener {
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent e) {
+        if (e.getBlock().getType() == Material.OBSIDIAN) {
+             e.setCancelled(true);
+        }
+    }
+}


### PR DESCRIPTION
Fix #21 by cancelling BlockBreakEvent if the block type is obsidian.